### PR TITLE
Feat/#14 - 홈화면/설정/튜토리얼 UI 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ jspm_packages/
 # Temporary folders
 tmp/
 temp/
+
+# package-lock
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -13,18 +13,18 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-router-dom": "^7.9.2",
     "styled-components": "^6.1.19",
     "zustand": "^4.4.7"
   },
   "devDependencies": {
-    "@types/react": "^18.2.43",
-    "@types/react-dom": "^18.2.17",
+    "@types/react": "^18.3.25",
+    "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import Home from "./pages/Home";
 
 
 const AppContainer = styled.div`
@@ -11,7 +12,7 @@ const AppContainer = styled.div`
 const App: React.FC = () => {
   return (
     <AppContainer>
-      
+      <Home />
     </AppContainer>
   );
 };

--- a/src/components/DinoCharacter.tsx
+++ b/src/components/DinoCharacter.tsx
@@ -1,0 +1,9 @@
+const DinoCharacter = () => {
+  return (
+    <div className="w-40 h-40 bg-white border-2 border-gray-400 rounded-full flex items-center justify-center text-sm text-gray-500 shadow-md">
+      두리 이미지 자리
+    </div>
+  );
+};
+
+export default DinoCharacter;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,16 +1,22 @@
 const Navbar = () => {
-  const menus = ["홈", "지도", "카드", "달력"];
+  const menus = [
+    { label: "홈", id: "nav-home" },
+    { label: "지도", id: "nav-map" },
+    { label: "카드", id: "nav-card" },
+    { label: "달력", id: "nav-calendar" },
+  ];
 
   return (
     <nav className="w-full flex justify-around items-center bg-white border-t border-gray-300 py-3 fixed bottom-0">
-      {menus.map((label) => (
+      {menus.map((m) => (
         <button
-          key={label}
+          key={m.id}
+          id={m.id}                                       
           className="flex flex-col items-center text-xs text-gray-600 hover:text-blue-500 transition-colors cursor-pointer"
-          onClick={() => console.log(`${label} 아이콘 클릭됨`)} // 클릭 반응만 확인용
+          onClick={() => console.log(`${m.label} 아이콘 클릭됨`)}
         >
           <div className="mb-1 text-[10px] text-gray-500">아이콘</div>
-          <span>{label}</span>
+          <span>{m.label}</span>
         </button>
       ))}
     </nav>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,20 @@
+const Navbar = () => {
+  const menus = ["홈", "지도", "카드", "달력"];
+
+  return (
+    <nav className="w-full flex justify-around items-center bg-white border-t border-gray-300 py-3 fixed bottom-0">
+      {menus.map((label) => (
+        <button
+          key={label}
+          className="flex flex-col items-center text-xs text-gray-600 hover:text-blue-500 transition-colors cursor-pointer"
+          onClick={() => console.log(`${label} 아이콘 클릭됨`)} // 클릭 반응만 확인용
+        >
+          <div className="mb-1 text-[10px] text-gray-500">아이콘</div>
+          <span>{label}</span>
+        </button>
+      ))}
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+
+interface Props {
+  onClose: () => void;
+}
+
+const SettingsModal: React.FC<Props> = ({ onClose }) => {
+  const [isOn, setIsOn] = useState(true);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+      <div className="bg-white rounded-xl shadow-lg w-80 py-5 relative">
+        {/* 제목 */}
+        <div className="text-center text-gray-800 text-lg font-semibold border-b pb-3">
+          환경 설정
+          <button
+            onClick={onClose}
+            className="absolute right-4 top-4 text-gray-400 hover:text-gray-600"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* 내용 */}
+        <div className="px-6 py-5 flex flex-col">
+          {/* 알림 토글 */}
+          <div className="flex justify-between items-center">
+            <div className="flex items-center gap-2">
+              <span className="text-yellow-500">🔔</span>
+              <span className="text-gray-700 font-medium">알림</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setIsOn(true)}
+                className={`text-xs px-3 py-1 rounded-md transition-colors ${
+                  isOn
+                    ? "bg-blue-500 text-white"
+                    : "bg-gray-200 text-gray-600 hover:bg-gray-300"
+                }`}
+              >
+                ON
+              </button>
+              <button
+                onClick={() => setIsOn(false)}
+                className={`text-xs px-3 py-1 rounded-md transition-colors ${
+                  !isOn
+                    ? "bg-blue-500 text-white"
+                    : "bg-gray-200 text-gray-600 hover:bg-gray-300"
+                }`}
+              >
+                OFF
+              </button>
+            </div>
+          </div>
+
+          {/* 구분선: 더 아래로 내림 */}
+          <div className="border-t border-gray-200 mt-10" />
+
+          {/* 로그아웃 버튼: 폭 좁게 중앙 배치 */}
+          <div className="flex justify-center mt-3">
+            <button className="text-gray-400 text-sm hover:text-red-500 transition w-fit px-4 py-1">
+              로그아웃
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsModal;

--- a/src/components/SideIcons.tsx
+++ b/src/components/SideIcons.tsx
@@ -1,0 +1,10 @@
+const SideIcons = () => {
+  return (
+    <div className="absolute left-5 top-1/2 -translate-y-1/2 flex flex-col gap-5">
+      <span role="img" aria-label="game" className="text-xl cursor-pointer select-none">🎮</span>
+      <span role="img" aria-label="food" className="text-xl cursor-pointer select-none">🍽️</span>
+    </div>
+  );
+};
+
+export default SideIcons;

--- a/src/components/SideIcons.tsx
+++ b/src/components/SideIcons.tsx
@@ -1,8 +1,8 @@
 const SideIcons = () => {
   return (
     <div className="absolute left-5 top-1/2 -translate-y-1/2 flex flex-col gap-5">
-      <span role="img" aria-label="game" className="text-xl cursor-pointer select-none">🎮</span>
-      <span role="img" aria-label="food" className="text-xl cursor-pointer select-none">🍽️</span>
+      <span id="icon-game"  className="text-xl cursor-pointer select-none">🎮</span>
+      <span id="icon-feed"  className="text-xl cursor-pointer select-none">🍽️</span>
     </div>
   );
 };

--- a/src/components/SpeechBox.tsx
+++ b/src/components/SpeechBox.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  text: string;
+}
+
+const SpeechBox: React.FC<Props> = ({ text }) => {
+  return (
+    <div className="bg-white border-2 border-gray-300 rounded-xl px-6 py-3 text-center shadow-md text-gray-700 text-sm w-72">
+      {text}
+    </div>
+  );
+};
+
+export default SpeechBox;

--- a/src/components/TopIcons.tsx
+++ b/src/components/TopIcons.tsx
@@ -1,10 +1,19 @@
-const TopIcons = () => {
+interface Props {
+  onSettingsClick?: () => void;
+}
+
+const TopIcons: React.FC<Props> = ({ onSettingsClick }) => {
   return (
     <div className="absolute top-5 right-5 flex gap-4">
       <span role="img" aria-label="bell" className="text-2xl cursor-pointer">
         🔔
       </span>
-      <span role="img" aria-label="settings" className="text-2xl cursor-pointer">
+      <span
+        role="img"
+        aria-label="settings"
+        className="text-2xl cursor-pointer select-none"
+        onClick={onSettingsClick}
+      >
         ⚙️
       </span>
     </div>

--- a/src/components/TopIcons.tsx
+++ b/src/components/TopIcons.tsx
@@ -1,0 +1,14 @@
+const TopIcons = () => {
+  return (
+    <div className="absolute top-5 right-5 flex gap-4">
+      <span role="img" aria-label="bell" className="text-2xl cursor-pointer">
+        🔔
+      </span>
+      <span role="img" aria-label="settings" className="text-2xl cursor-pointer">
+        ⚙️
+      </span>
+    </div>
+  );
+};
+
+export default TopIcons;

--- a/src/components/TopIcons.tsx
+++ b/src/components/TopIcons.tsx
@@ -1,21 +1,10 @@
-interface Props {
-  onSettingsClick?: () => void;
-}
+interface Props { onSettingsClick?: () => void }
 
 const TopIcons: React.FC<Props> = ({ onSettingsClick }) => {
   return (
     <div className="absolute top-5 right-5 flex gap-4">
-      <span role="img" aria-label="bell" className="text-2xl cursor-pointer">
-        🔔
-      </span>
-      <span
-        role="img"
-        aria-label="settings"
-        className="text-2xl cursor-pointer select-none"
-        onClick={onSettingsClick}
-      >
-        ⚙️
-      </span>
+      <span id="icon-bell"    className="text-2xl cursor-pointer select-none">🔔</span>
+      <span id="icon-gear"    className="text-2xl cursor-pointer select-none" onClick={onSettingsClick}>⚙️</span>
     </div>
   );
 };

--- a/src/components/TutorialOverlay.tsx
+++ b/src/components/TutorialOverlay.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+type Step = { id: string; message: string };
+
+const steps: Step[] = [
+  { id: "nav-map",     message: "가맹점 지도를 확인할 수 있습니다." },
+  { id: "nav-card",    message: "내 카드 혜택과 정보를 관리할 수 있습니다." },
+  { id: "nav-calendar",message: "카드 사용 내역을 확인할 수 있습니다." },
+  { id: "icon-feed",   message: "두리에게 먹이를 주세요!" },
+  { id: "icon-game",   message: "게임으로 먹이를 모아보세요." },
+  { id: "icon-bell",   message: "알림에서 새로운 소식을 확인하세요." },
+];
+
+const PADDING = 8;      // 하이라이트 여백
+const BUBBLE_W = 320;   // 말풍선 가로폭
+
+const TutorialOverlay: React.FC<{ onClose: () => void }> = ({ onClose }) => {
+  const [idx, setIdx] = useState(0);
+  const [box, setBox] = useState<{top:number;left:number;width:number;height:number}>({
+    top: 0, left: 0, width: 0, height: 0
+  });
+  const [bubble, setBubble] = useState<{top:number;left:number}>({ top: 0, left: 0 });
+
+  const current = useMemo(() => steps[idx], [idx]);
+
+  // 현재 step의 DOM 위치 측정
+  const measure = () => {
+    const el = document.getElementById(current.id);
+    if (!el) return;
+
+    const r = el.getBoundingClientRect();
+    const top  = Math.max(0, r.top - PADDING);
+    const left = Math.max(0, r.left - PADDING);
+    const width  = r.width  + PADDING * 2;
+    const height = r.height + PADDING * 2;
+    setBox({ top, left, width, height });
+
+    // 말풍선 위치: 기본은 하이라이트 위, 공간이 부족하면 아래
+    const aboveTop = top - 96; // 버블 높이 대략
+    const placeBelow = aboveTop < 12;
+    const bubbleTop = placeBelow ? top + height + 12 : aboveTop;
+    let bubbleLeft = left + width / 2 - BUBBLE_W / 2;
+    bubbleLeft = Math.min(window.innerWidth - BUBBLE_W - 12, Math.max(12, bubbleLeft));
+    setBubble({ top: bubbleTop, left: bubbleLeft });
+  };
+
+  useEffect(() => {
+    measure();
+    // 화면 변화에 대응
+    const onResize = () => measure();
+    window.addEventListener("resize", onResize);
+    window.addEventListener("orientationchange", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("orientationchange", onResize);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [current.id]);
+
+  return (
+    <div className="fixed inset-0 z-50">
+      {/* 어둡게 */}
+      <div className="absolute inset-0 bg-black/60" />
+
+      {/* 하이라이트 박스 */}
+      <div
+        className="fixed border-4 border-yellow-400 rounded-2xl transition-all duration-200 pointer-events-none"
+        style={{ top: box.top, left: box.left, width: box.width, height: box.height }}
+      />
+
+      {/* 말풍선 */}
+      <div
+        className="fixed z-[60] bg-white rounded-2xl shadow-xl px-4 py-3"
+        style={{ top: bubble.top, left: bubble.left, width: BUBBLE_W }}
+      >
+        <p className="text-sm text-gray-800">{current.message}</p>
+        <div className="flex justify-end mt-2">
+          {idx < steps.length - 1 ? (
+            <button
+              onClick={() => setIdx((i) => i + 1)}
+              className="text-blue-600 font-semibold text-sm"
+            >
+              다음 →
+            </button>
+          ) : (
+            <button onClick={onClose} className="text-gray-500 text-sm hover:text-red-500">
+              튜토리얼 종료
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TutorialOverlay;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,27 +3,32 @@ import SideIcons from "../components/SideIcons";
 import DinoCharacter from "../components/DinoCharacter";
 import SpeechBox from "../components/SpeechBox";
 import Navbar from "../components/Navbar";
+import SettingsModal from "../components/SettingsModal";
+import { useState } from "react";
 
 const Home = () => {
-  return (
-    <div className="relative w-full h-screen bg-gradient-to-b from-sky-200 to-green-200 flex items-center justify-center overflow-hidden">
-      {/* 우측 상단: 알림/설정 */}
-      <TopIcons />
-      {/* 좌측 중앙: 게임/식사 */}
-      <SideIcons />
+    const [showSettings, setShowSettings] = useState(false);
 
-      {/* 중앙: 두리 자리 */}
-      <DinoCharacter />
+    return (
+        <div className="relative w-full h-screen bg-gradient-to-b from-sky-200 to-green-200 flex items-center justify-center overflow-hidden">
+            {/* 우측 상단: 알림/설정 */}
+            <TopIcons onSettingsClick={() => setShowSettings(true)} />
+            {/* 좌측 중앙: 게임/식사 */}
+            <SideIcons />
 
-      {/* 하단 메뉴 바로 위: 메시지 박스 */}
-      <div className="absolute bottom-20 w-full flex justify-center">
-        <SpeechBox text="메세지 박스 자리" />
-      </div>
+            {/* 중앙: 두리 자리 */}
+            <DinoCharacter />
 
-      {/* 하단 네비게이션 */}
-      <Navbar />
-    </div>
-  );
+            {/* 하단 메뉴 바로 위: 메시지 박스 */}
+            <div className="absolute bottom-20 w-full flex justify-center">
+                <SpeechBox text="메세지 박스 자리" />
+            </div>
+
+            {/* 하단 네비게이션 */}
+            <Navbar />
+            {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
+        </div>
+    );
 };
 
 export default Home;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,29 @@
+import TopIcons from "../components/TopIcons";
+import SideIcons from "../components/SideIcons";
+import DinoCharacter from "../components/DinoCharacter";
+import SpeechBox from "../components/SpeechBox";
+import Navbar from "../components/Navbar";
+
+const Home = () => {
+  return (
+    <div className="relative w-full h-screen bg-gradient-to-b from-sky-200 to-green-200 flex items-center justify-center overflow-hidden">
+      {/* 우측 상단: 알림/설정 */}
+      <TopIcons />
+      {/* 좌측 중앙: 게임/식사 */}
+      <SideIcons />
+
+      {/* 중앙: 두리 자리 */}
+      <DinoCharacter />
+
+      {/* 하단 메뉴 바로 위: 메시지 박스 */}
+      <div className="absolute bottom-20 w-full flex justify-center">
+        <SpeechBox text="메세지 박스 자리" />
+      </div>
+
+      {/* 하단 네비게이션 */}
+      <Navbar />
+    </div>
+  );
+};
+
+export default Home;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,10 +4,12 @@ import DinoCharacter from "../components/DinoCharacter";
 import SpeechBox from "../components/SpeechBox";
 import Navbar from "../components/Navbar";
 import SettingsModal from "../components/SettingsModal";
+import TutorialOverlay from "../components/TutorialOverlay";
 import { useState } from "react";
 
 const Home = () => {
     const [showSettings, setShowSettings] = useState(false);
+    const [showTutorial, setShowTutorial] = useState(false);
 
     return (
         <div className="relative w-full h-screen bg-gradient-to-b from-sky-200 to-green-200 flex items-center justify-center overflow-hidden">
@@ -27,7 +29,21 @@ const Home = () => {
             {/* 하단 네비게이션 */}
             <Navbar />
             {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
-        </div>
+
+
+            {/* 🧭 튜토리얼 보기 버튼 (왼쪽 상단) */}
+            <button
+                className="absolute top-4 left-4 text-gray-700 bg-white bg-opacity-60 rounded-full px-3 py-1 text-sm hover:bg-opacity-80"
+                onClick={() => setShowTutorial(true)}
+            >
+                🧭 튜토리얼 보기
+            </button>
+
+            {/* 튜토리얼 오버레이 */}
+            {showTutorial && (
+                <TutorialOverlay onClose={() => setShowTutorial(false)} />
+            )}
+        </div >
     );
 };
 


### PR DESCRIPTION
## 📌 Summary
- 홈 화면 구현
-> 두리 캐릭터, 상단 아이콘(알림, 설정), 측면 메뉴(게임,먹이주기), 하단 네비게이션 구성
-> 설정창(SettingsModal)과 튜토리얼(TutorialOverlay) 연동 완료

- 환경 설정 구현
-> 알림 ON/OFF 토글 기능
-> 로그아웃 버튼 및 구분선 정리
-> 모달 형태로 홈 화면 위에 표시

- 튜토리얼 구현
-> 앱 주요 기능(지도, 카드, 달력, 먹이주기, 게임, 알림) 순서대로 안내
-> 클릭 시 다음 단계로 이동하며, 실제 요소 위치 자동 감지 및 강조
-> 모바일 화면에서도 반응형으로 동작하도록 좌표 계산 및 정렬 처리


## ✍️ Description
- close: #14 

## 💡 PR Point
튜토리얼 화면 수정했습니다. 한번에 보여주는 것 보다 순차적으로 보여주는 것이 괜찮을 것 같습니다.


## 📚 Reference 



## 🔥 Test
<img width="372" height="755" alt="스크린샷 2025-10-07 오후 9 26 38" src="https://github.com/user-attachments/assets/66023638-e114-4e15-af0d-b452fe1449cd" />
<img width="365" height="748" alt="스크린샷 2025-10-07 오후 9 27 02" src="https://github.com/user-attachments/assets/9fe73ec0-ebc1-43a6-95bb-8ea43c5b24d4" />
<img width="368" height="747" alt="스크린샷 2025-10-07 오후 9 27 27" src="https://github.com/user-attachments/assets/ec17e34e-6983-4f0d-9922-2d7cd7a7e114" />
<img width="363" height="746" alt="스크린샷 2025-10-07 오후 9 27 38" src="https://github.com/user-attachments/assets/62737569-9456-43a3-b9ee-c39e6288517d" />
<img width="364" height="745" alt="스크린샷 2025-10-07 오후 9 27 53" src="https://github.com/user-attachments/assets/8a661c3f-e347-45c6-be08-835059cc9197" />
<img width="367" height="749" alt="스크린샷 2025-10-07 오후 9 28 04" src="https://github.com/user-attachments/assets/c2546459-7deb-4715-bfb2-6cf7d1c72107" />
<img width="362" height="745" alt="스크린샷 2025-10-07 오후 9 28 14" src="https://github.com/user-attachments/assets/dae51fd8-94ae-4cc4-8810-fb499ad4befe" />
<img width="362" height="745" alt="스크린샷 2025-10-07 오후 9 28 27" src="https://github.com/user-attachments/assets/6a5689b6-c85e-4507-b506-78b73425d619" />



